### PR TITLE
Adjust styling table formatting and bright/non-bright terminal colours

### DIFF
--- a/styling.md
+++ b/styling.md
@@ -33,8 +33,8 @@ We offer guidelines for both dark and light themes:
 
 Each colour (baseNN) serves a specific purpose or use case, such as background, foreground, variables, etc. Here's a breakdown:
 
-| Colour  | BaseNN | Ansi | Terminal/Colour Use | Text Editor |
-| ------ | ------ | ---- | ------------------- | ----------- |
+| Colour                                                  | BaseNN | Ansi | Terminal/Colour Use | Text Editor |
+| ------------------------------------------------------- | ------ | ---- | ------------------- | ----------- |
 | ![Colour](https://placehold.it/25/282c34/000000?text=+) | base00 | -    | Background          | Default Background |
 | ![Colour](https://placehold.it/25/3f4451/000000?text=+) | base01 | 0    | Black               | Lighter Background (Used for status bars) |
 | ![Colour](https://placehold.it/25/4f5666/000000?text=+) | base02 | 8    | Bright Black        | Selection Background |
@@ -43,21 +43,21 @@ Each colour (baseNN) serves a specific purpose or use case, such as background, 
 | ![Colour](https://placehold.it/25/abb2bf/000000?text=+) | base05 | -    | Foreground          | Default Foreground, Caret, Delimiters, Operators |
 | ![Colour](https://placehold.it/25/e6e6e6/000000?text=+) | base06 | 7    | White               | Light Foreground (Not often used) |
 | ![Colour](https://placehold.it/25/ffffff/000000?text=+) | base07 | 15   | Bright White        | The Lightest Foreground (Not often used) |
-| ![Colour](https://placehold.it/25/e06c75/000000?text=+) | base08 | 1    | Red                 | Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted |
-| ![Colour](https://placehold.it/25/d19a66/000000?text=+) | base09 | 3    | Yellow              | Integers, Boolean, Constants, XML Attributes, Markup Link Url |
-| ![Colour](https://placehold.it/25/e5c07b/000000?text=+) | base0A | ~11  | (Bright Yellow)     | Classes, Markup Bold, Search Text Background |
-| ![Colour](https://placehold.it/25/98c379/000000?text=+) | base0B | 2    | Green               | Strings, Inherited Class, Markup Code, Diff Inserted |
-| ![Colour](https://placehold.it/25/56b6c2/000000?text=+) | base0C | 6    | Cyan                | Support, Regular Expressions, Escape Characters, Markup Quotes |
-| ![Colour](https://placehold.it/25/61afef/000000?text=+) | base0D | 4    | Blue                | Functions, Methods, Attribute IDs, Headings |
-| ![Colour](https://placehold.it/25/c678dd/000000?text=+) | base0E | 5    | Purple              | Keywords, Storage, Selector, Markup Italic, Diff Changed |
-| ![Colour](https://placehold.it/25/be5046/000000?text=+) | base0F | -    | (Dark Red/Brown)    | Deprecated Highlighting for Methods and Functions, Opening/Closing Embedded Language Tags, e.g., `<?php ?>` |
-| ![Colour](https://placehold.it/25/21252b/000000?text=+) | base10 | -    | ('Darker' Black)    | Darker Background |
-| ![Colour](https://placehold.it/25/181a1f/000000?text=+) | base11 | -    | ('Darkest' Black)   | The Darkest Background |
-| ![Colour](https://placehold.it/25/ff7b86/000000?text=+) | base12 | 9    | Bright Red          | NA |
-| ![Colour](https://placehold.it/25/efb074/000000?text=+) | base13 | 11   | Bright Yellow       | NA |
-| ![Colour](https://placehold.it/25/b1e18b/000000?text=+) | base14 | 10   | Bright Green        | NA |
-| ![Colour](https://placehold.it/25/63d4e0/000000?text=+) | base15 | 14   | Bright Cyan         | NA |
-| ![Colour](https://placehold.it/25/67cdff/000000?text=+) | base16 | 12   | Bright Blue         | NA |
-| ![Colour](https://placehold.it/25/e48bff/000000?text=+) | base17 | 13   | Bright Purple       | NA |
+| ![Colour](https://placehold.it/25/e06c75/000000?text=+) | base08 | 9    | Bright Red          | Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted |
+| ![Colour](https://placehold.it/25/d19a66/000000?text=+) | base09 | ~3   | (Orange)            | Integers, Boolean, Constants, XML Attributes, Markup Link Url |
+| ![Colour](https://placehold.it/25/e5c07b/000000?text=+) | base0A | 11   | Bright Yellow       | Classes, Markup Bold, Search Text Background |
+| ![Colour](https://placehold.it/25/98c379/000000?text=+) | base0B | 10   | Bright Green        | Strings, Inherited Class, Markup Code, Diff Inserted |
+| ![Colour](https://placehold.it/25/56b6c2/000000?text=+) | base0C | 14   | Bright Cyan         | Support, Regular Expressions, Escape Characters, Markup Quotes |
+| ![Colour](https://placehold.it/25/61afef/000000?text=+) | base0D | 12   | Bright Blue         | Functions, Methods, Attribute IDs, Headings |
+| ![Colour](https://placehold.it/25/c678dd/000000?text=+) | base0E | 13   | Bright Purple       | Keywords, Storage, Selector, Markup Italic, Diff Changed |
+| ![Colour](https://placehold.it/25/be5046/000000?text=+) | base0F | -    | (Dark Red or Brown) | Deprecated Highlighting for Methods and Functions, Opening/Closing Embedded Language Tags, e.g., `<?php ?>` |
+| ![Colour](https://placehold.it/25/21252b/000000?text=+) | base10 | -    | (Darker Black)      | Darker Background |
+| ![Colour](https://placehold.it/25/181a1f/000000?text=+) | base11 | -    | (Darkest Black)     | The Darkest Background |
+| ![Colour](https://placehold.it/25/ff7b86/000000?text=+) | base12 | 1    | Red                 | NA |
+| ![Colour](https://placehold.it/25/efb074/000000?text=+) | base13 | 3    | Yellow              | NA |
+| ![Colour](https://placehold.it/25/b1e18b/000000?text=+) | base14 | 2    | Green               | NA |
+| ![Colour](https://placehold.it/25/63d4e0/000000?text=+) | base15 | 6    | Cyan                | NA |
+| ![Colour](https://placehold.it/25/67cdff/000000?text=+) | base16 | 4    | Blue                | NA |
+| ![Colour](https://placehold.it/25/e48bff/000000?text=+) | base17 | 5    | Purple              | NA |
 
 Note: Items in parenthesis for the Terminal/Colour Use do not have an identified terminal use and are a more generic colour description. Implementation may vary depending on the Base24 scheme.


### PR DESCRIPTION
I've created a PR https://github.com/tinted-theming/home/pull/110 which makes the bright/non-bright situation a bit more explicit for Base16.

Since Base24 is a superset of base16, we should theoretically be able to use a base24 colour palette for base16 and it would generate the same thing. The way things are now Base24's `base08` - `base0E` is considered "not bright", however the colours used here tend to be less saturated than `base10` - `base17` - so in practise Base24's "bright" terminal colours are typically less bright.

People also tend make themes with highly saturated colours, so adding a "bright" variant becomes more difficult than adding a less saturated variant. Of course this isn't always the case, there can be themes that have low saturation, and in those cases a bright variant would be easy to add and a less saturated variant would be more difficult to add, so things won't always work out perfectly.

With this in mind, what are your thoughts with this edit? Do you agree with the above, etc?